### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,8 @@
 name: Python Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,8 +1,5 @@
 name: Python Tests
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [ main ]
@@ -12,6 +9,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+        checks: write
+        pull-requests: write
+        contents: read
+        issues: read
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/saphetor/dx-vc-file-transfer/security/code-scanning/1](https://github.com/saphetor/dx-vc-file-transfer/security/code-scanning/1)

The best way to fix this issue is to add a `permissions` block at the root of the workflow. This block will define the least privileges required for the workflow to operate securely. Since this workflow only needs to read repository contents and does not perform any `write` operations, the `permissions` should be set to `contents: read`. 

Steps:
1. Add a `permissions` key at the root level of the workflow.
2. Set `contents: read` as the permission value to limit access to only reading repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
